### PR TITLE
jx-spring-boot-rest-prometheus to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.58
 - name: jx-spring-boot-rest-prometheus
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote jx-spring-boot-rest-prometheus to version 0.0.2